### PR TITLE
Fix possible crashes

### DIFF
--- a/app/src/main/java/org/koitharu/kotatsu/base/ui/BaseActivity.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/base/ui/BaseActivity.kt
@@ -59,12 +59,12 @@ abstract class BaseActivity<B : ViewBinding> : AppCompatActivity(), OnApplyWindo
 		this.binding = binding
 		super.setContentView(binding.root)
 		(binding.root.findViewById<View>(R.id.toolbar) as? Toolbar)?.let(this::setSupportActionBar)
-		val params = (binding.root.findViewById<View>(R.id.toolbar) as? Toolbar)?.layoutParams as AppBarLayout.LayoutParams
+		val params = (binding.root.findViewById<View>(R.id.toolbar) as? Toolbar)?.layoutParams as? AppBarLayout.LayoutParams
 		ViewCompat.setOnApplyWindowInsetsListener(binding.root, this)
 		if (get<AppSettings>().isToolbarHideWhenScrolling) {
-			params.scrollFlags = SCROLL_FLAG_SCROLL or SCROLL_FLAG_ENTER_ALWAYS
+			params?.scrollFlags = SCROLL_FLAG_SCROLL or SCROLL_FLAG_ENTER_ALWAYS
 		} else {
-			params.scrollFlags = SCROLL_FLAG_NO_SCROLL
+			params?.scrollFlags = SCROLL_FLAG_NO_SCROLL
 		}
 	}
 


### PR DESCRIPTION
Fixed an application crash when updating from 1.0 to 1.1. Also, an app also crashes when trying to protect the application. I recommend to create a version of the hotfix 1.1.1.

UPD: Tested, when updating from version 1.0 to the version with the fix, nothing crashes, everything works perfectly.