### PR TITLE
Fix app crash on the first use

### DIFF
--- a/app/src/main/java/org/koitharu/kotatsu/core/db/DatabasePrePopulateCallback.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/core/db/DatabasePrePopulateCallback.kt
@@ -4,13 +4,14 @@ import android.content.res.Resources
 import androidx.room.RoomDatabase
 import androidx.sqlite.db.SupportSQLiteDatabase
 import org.koitharu.kotatsu.R
+import org.koitharu.kotatsu.core.model.SortOrder
 
 class DatabasePrePopulateCallback(private val resources: Resources) : RoomDatabase.Callback() {
 
 	override fun onCreate(db: SupportSQLiteDatabase) {
 		db.execSQL(
-			"INSERT INTO favourite_categories (created_at, sort_key, title) VALUES (?,?,?)",
-			arrayOf(System.currentTimeMillis(), 1, resources.getString(R.string.read_later))
+			"INSERT INTO favourite_categories (created_at, sort_key, title, `order`) VALUES (?,?,?,?)",
+			arrayOf(System.currentTimeMillis(), 1, resources.getString(R.string.read_later), SortOrder.NEWEST.name)
 		)
 	}
 }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -45,7 +45,7 @@
 	</style>
 
 	<style name="AppTheme" parent="Base.AppTheme">
-		<item name="android:statusBarColor">@color/grey</item>
+		<item name="android:statusBarColor">@color/nav_bar_scrim</item>
 	</style>
 
 	<style name="AppTheme.AMOLED" parent="Base.AppTheme" />


### PR DESCRIPTION
This PR fixes SQLite error `[INSERT INTO favourite_categories (created_at, sort_key, title) VALUES (?,?,?)]: NOT NULL constraint failed: favourite_categories.order`. This will prevent from being unable to use the application during the first installation.