### PR TITLE
Made UI more like Google apps

### DIFF
--- a/app/src/main/java/org/koitharu/kotatsu/base/ui/BaseActivity.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/base/ui/BaseActivity.kt
@@ -64,7 +64,7 @@ abstract class BaseActivity<B : ViewBinding> : AppCompatActivity(), OnApplyWindo
 			?.layoutParams as? AppBarLayout.LayoutParams
 		if (toolbarParams != null) {
 			if (get<AppSettings>().isToolbarHideWhenScrolling) {
-				toolbarParams.scrollFlags = SCROLL_FLAG_SCROLL or SCROLL_FLAG_ENTER_ALWAYS
+				toolbarParams.scrollFlags = SCROLL_FLAG_SCROLL or SCROLL_FLAG_ENTER_ALWAYS or SCROLL_FLAG_SNAP
 			} else {
 				toolbarParams.scrollFlags = SCROLL_FLAG_NO_SCROLL
 			}

--- a/app/src/main/java/org/koitharu/kotatsu/favourites/ui/FavouritesContainerFragment.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/favourites/ui/FavouritesContainerFragment.kt
@@ -3,6 +3,7 @@ package org.koitharu.kotatsu.favourites.ui
 import android.os.Bundle
 import android.view.*
 import androidx.core.graphics.Insets
+import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.Snackbar
@@ -18,6 +19,7 @@ import org.koitharu.kotatsu.favourites.ui.categories.CategoriesEditDelegate
 import org.koitharu.kotatsu.favourites.ui.categories.FavouritesCategoriesViewModel
 import org.koitharu.kotatsu.utils.RecycledViewPoolHolder
 import org.koitharu.kotatsu.utils.ext.getDisplayMessage
+import org.koitharu.kotatsu.utils.ext.resolveDp
 import org.koitharu.kotatsu.utils.ext.showPopupMenu
 import java.util.*
 
@@ -65,10 +67,18 @@ class FavouritesContainerFragment : BaseFragment<FragmentFavouritesBinding>(),
 	}
 
 	override fun onWindowInsetsChanged(insets: Insets) {
-		binding.tabs.updatePadding(
-			left = insets.left,
-			right = insets.right
+		binding.pager.updatePadding(
+			top = -(resources.resolveDp(56) + insets.top)
 		)
+		binding.tabs.apply {
+			updatePadding(
+				left = insets.left,
+				right = insets.right
+			)
+			updateLayoutParams<ViewGroup.MarginLayoutParams> {
+				topMargin = insets.top
+			}
+		}
 	}
 
 	private fun onCategoriesChanged(categories: List<FavouriteCategory>) {

--- a/app/src/main/java/org/koitharu/kotatsu/favourites/ui/FavouritesContainerFragment.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/favourites/ui/FavouritesContainerFragment.kt
@@ -6,6 +6,7 @@ import androidx.core.graphics.Insets
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayoutMediator
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -19,7 +20,7 @@ import org.koitharu.kotatsu.favourites.ui.categories.CategoriesEditDelegate
 import org.koitharu.kotatsu.favourites.ui.categories.FavouritesCategoriesViewModel
 import org.koitharu.kotatsu.utils.RecycledViewPoolHolder
 import org.koitharu.kotatsu.utils.ext.getDisplayMessage
-import org.koitharu.kotatsu.utils.ext.resolveDp
+import org.koitharu.kotatsu.utils.ext.measureHeight
 import org.koitharu.kotatsu.utils.ext.showPopupMenu
 import java.util.*
 
@@ -67,8 +68,12 @@ class FavouritesContainerFragment : BaseFragment<FragmentFavouritesBinding>(),
 	}
 
 	override fun onWindowInsetsChanged(insets: Insets) {
+		val headerHeight = requireActivity().findViewById<AppBarLayout>(R.id.appbar).measureHeight()
+		binding.root.updatePadding(
+			top = headerHeight - insets.top
+		)
 		binding.pager.updatePadding(
-			top = -(resources.resolveDp(56) + insets.top)
+			top = -headerHeight
 		)
 		binding.tabs.apply {
 			updatePadding(

--- a/app/src/main/java/org/koitharu/kotatsu/list/ui/MangaListFragment.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/list/ui/MangaListFragment.kt
@@ -14,6 +14,7 @@ import androidx.drawerlayout.widget.DrawerLayout
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.get
@@ -222,7 +223,7 @@ abstract class MangaListFragment : BaseFragment<FragmentListBinding>(),
 	}
 
 	override fun onWindowInsetsChanged(insets: Insets) {
-		val headerHeight = insets.top + resources.resolveDp(64)
+		val headerHeight = requireActivity().findViewById<AppBarLayout>(R.id.appbar).measureHeight()
 		binding.recyclerViewFilter.updatePadding(
 			top = headerHeight,
 			bottom = insets.bottom

--- a/app/src/main/java/org/koitharu/kotatsu/list/ui/MangaListFragment.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/list/ui/MangaListFragment.kt
@@ -36,11 +36,9 @@ import org.koitharu.kotatsu.list.ui.adapter.MangaListAdapter
 import org.koitharu.kotatsu.list.ui.filter.FilterAdapter
 import org.koitharu.kotatsu.list.ui.filter.OnFilterChangedListener
 import org.koitharu.kotatsu.list.ui.model.ListModel
+import org.koitharu.kotatsu.main.ui.MainActivity
 import org.koitharu.kotatsu.utils.RecycledViewPoolHolder
-import org.koitharu.kotatsu.utils.ext.clearItemDecorations
-import org.koitharu.kotatsu.utils.ext.getDisplayMessage
-import org.koitharu.kotatsu.utils.ext.toggleDrawer
-import org.koitharu.kotatsu.utils.ext.viewLifecycleScope
+import org.koitharu.kotatsu.utils.ext.*
 
 abstract class MangaListFragment : BaseFragment<FragmentListBinding>(),
 	PaginationScrollListener.Callback, OnListItemClickListener<Manga>, OnFilterChangedListener,
@@ -224,16 +222,26 @@ abstract class MangaListFragment : BaseFragment<FragmentListBinding>(),
 	}
 
 	override fun onWindowInsetsChanged(insets: Insets) {
-		binding.recyclerView.updatePadding(
-			bottom = insets.bottom
-		)
+		val headerHeight = insets.top + resources.resolveDp(64)
 		binding.recyclerViewFilter.updatePadding(
+			top = headerHeight,
 			bottom = insets.bottom
 		)
 		binding.root.updatePadding(
 			left = insets.left,
 			right = insets.right
 		)
+		if (activity is MainActivity) {
+			binding.recyclerView.updatePadding(
+				top = headerHeight,
+				bottom = insets.bottom
+			)
+			binding.swipeRefreshLayout.setProgressViewOffset(
+				true,
+				headerHeight + resources.resolveDp(-72),
+				headerHeight + resources.resolveDp(10)
+			)
+		}
 	}
 
 	private fun onGridScaleChanged(scale: Float) {

--- a/app/src/main/java/org/koitharu/kotatsu/main/ui/MainActivity.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/main/ui/MainActivity.kt
@@ -47,10 +47,7 @@ import org.koitharu.kotatsu.settings.SettingsActivity
 import org.koitharu.kotatsu.settings.onboard.OnboardDialogFragment
 import org.koitharu.kotatsu.tracker.ui.FeedFragment
 import org.koitharu.kotatsu.tracker.work.TrackWorker
-import org.koitharu.kotatsu.utils.ext.getDisplayMessage
-import org.koitharu.kotatsu.utils.ext.hideKeyboard
-import org.koitharu.kotatsu.utils.ext.navigationItemBackground
-import org.koitharu.kotatsu.utils.ext.resolveDp
+import org.koitharu.kotatsu.utils.ext.*
 
 class MainActivity : BaseActivity<ActivityMainBinding>(),
 	NavigationView.OnNavigationItemSelectedListener,
@@ -91,7 +88,8 @@ class MainActivity : BaseActivity<ActivityMainBinding>(),
 		}
 
 		with(binding.navigationView) {
-			val menuView = findViewById<RecyclerView>(com.google.android.material.R.id.design_navigation_view)
+			val menuView =
+				findViewById<RecyclerView>(com.google.android.material.R.id.design_navigation_view)
 			ViewCompat.setOnApplyWindowInsetsListener(navHeaderBinding.root) { v, insets ->
 				val systemWindowInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
 				v.updatePadding(top = systemWindowInsets.top)
@@ -213,6 +211,9 @@ class MainActivity : BaseActivity<ActivityMainBinding>(),
 			leftMargin = insets.left + topMargin
 			rightMargin = insets.right + topMargin
 		}
+		binding.container.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+			topMargin = -(resources.resolveDp(66) + insets.top)
+		}
 	}
 
 	override fun onFocusChange(v: View?, hasFocus: Boolean) {
@@ -332,6 +333,8 @@ class MainActivity : BaseActivity<ActivityMainBinding>(),
 	private fun onSearchOpened() {
 		binding.drawer.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED)
 		drawerToggle.isDrawerIndicatorEnabled = false
+		// Avoiding shadows on the sides if the color is transparent, so we make the AppBarLayout white/dark
+		binding.appbar.setBackgroundColor(resources.getColor(R.color.color_on_secondary))
 		binding.toolbarCard.cardElevation = 0f
 		binding.appbar.elevation = searchViewElevation
 	}
@@ -339,6 +342,8 @@ class MainActivity : BaseActivity<ActivityMainBinding>(),
 	private fun onSearchClosed() {
 		binding.drawer.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED)
 		drawerToggle.isDrawerIndicatorEnabled = true
+		// Returning transparent color
+		binding.appbar.setBackgroundColor(resources.getColor(android.R.color.transparent))
 		binding.appbar.elevation = 0f
 		binding.toolbarCard.cardElevation = searchViewElevation
 	}

--- a/app/src/main/java/org/koitharu/kotatsu/main/ui/MainActivity.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/main/ui/MainActivity.kt
@@ -212,7 +212,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(),
 			rightMargin = insets.right + topMargin
 		}
 		binding.container.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-			topMargin = -(resources.resolveDp(66) + insets.top)
+			topMargin = -(binding.appbar.measureHeight())
 		}
 	}
 

--- a/app/src/main/java/org/koitharu/kotatsu/reader/ui/thumbnails/PagesThumbnailsSheet.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/reader/ui/thumbnails/PagesThumbnailsSheet.kt
@@ -59,7 +59,13 @@ class PagesThumbnailsSheet : BaseBottomSheet<SheetPagesBinding>(),
 		binding.toolbar.title = title
 		binding.toolbar.setNavigationOnClickListener { dismiss() }
 		binding.toolbar.subtitle = null
-		binding.toolbar.navigationIcon = null
+
+		if (!resources.getBoolean(R.bool.is_tablet)) {
+			binding.toolbar.navigationIcon = null
+		} else {
+			binding.toolbar.subtitle =
+				resources.getQuantityString(R.plurals.pages, thumbnails.size, thumbnails.size)
+		}
 
 		val initialTopPosition = binding.recyclerView.top
 
@@ -98,7 +104,9 @@ class PagesThumbnailsSheet : BaseBottomSheet<SheetPagesBinding>(),
 					if (newState == BottomSheetBehavior.STATE_EXPANDED) {
 						binding.toolbar.setNavigationIcon(R.drawable.ic_cross)
 						binding.toolbar.subtitle =
-							resources.getQuantityString(R.plurals.pages, thumbnails.size, thumbnails.size)
+							resources.getQuantityString(R.plurals.pages,
+								thumbnails.size,
+								thumbnails.size)
 					} else {
 						binding.toolbar.navigationIcon = null
 						binding.toolbar.subtitle = null

--- a/app/src/main/java/org/koitharu/kotatsu/search/ui/suggestion/SearchSuggestionFragment.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/search/ui/suggestion/SearchSuggestionFragment.kt
@@ -12,6 +12,7 @@ import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 import org.koitharu.kotatsu.base.ui.BaseFragment
 import org.koitharu.kotatsu.databinding.FragmentSearchSuggestionBinding
 import org.koitharu.kotatsu.search.ui.suggestion.adapter.SearchSuggestionAdapter
+import org.koitharu.kotatsu.utils.ext.resolveDp
 
 class SearchSuggestionFragment : BaseFragment<FragmentSearchSuggestionBinding>(),
 	SearchSuggestionItemCallback.SuggestionItemListener {
@@ -40,6 +41,7 @@ class SearchSuggestionFragment : BaseFragment<FragmentSearchSuggestionBinding>()
 
 	override fun onWindowInsetsChanged(insets: Insets) {
 		binding.root.updatePadding(
+			top = resources.resolveDp(64) + insets.top,
 			left = insets.left,
 			right = insets.right,
 			bottom = insets.bottom,

--- a/app/src/main/java/org/koitharu/kotatsu/search/ui/suggestion/SearchSuggestionFragment.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/search/ui/suggestion/SearchSuggestionFragment.kt
@@ -7,12 +7,14 @@ import android.view.ViewGroup
 import androidx.core.graphics.Insets
 import androidx.core.view.updatePadding
 import androidx.recyclerview.widget.ItemTouchHelper
+import com.google.android.material.appbar.AppBarLayout
 import org.koin.android.ext.android.get
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
+import org.koitharu.kotatsu.R
 import org.koitharu.kotatsu.base.ui.BaseFragment
 import org.koitharu.kotatsu.databinding.FragmentSearchSuggestionBinding
 import org.koitharu.kotatsu.search.ui.suggestion.adapter.SearchSuggestionAdapter
-import org.koitharu.kotatsu.utils.ext.resolveDp
+import org.koitharu.kotatsu.utils.ext.measureHeight
 
 class SearchSuggestionFragment : BaseFragment<FragmentSearchSuggestionBinding>(),
 	SearchSuggestionItemCallback.SuggestionItemListener {
@@ -41,7 +43,7 @@ class SearchSuggestionFragment : BaseFragment<FragmentSearchSuggestionBinding>()
 
 	override fun onWindowInsetsChanged(insets: Insets) {
 		binding.root.updatePadding(
-			top = resources.resolveDp(64) + insets.top,
+			top = requireActivity().findViewById<AppBarLayout>(R.id.appbar).measureHeight(),
 			left = insets.left,
 			right = insets.right,
 			bottom = insets.bottom,

--- a/app/src/main/java/org/koitharu/kotatsu/tracker/ui/FeedFragment.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/tracker/ui/FeedFragment.kt
@@ -20,6 +20,7 @@ import org.koitharu.kotatsu.list.ui.model.ListModel
 import org.koitharu.kotatsu.tracker.ui.adapter.FeedAdapter
 import org.koitharu.kotatsu.tracker.work.TrackWorker
 import org.koitharu.kotatsu.utils.ext.getDisplayMessage
+import org.koitharu.kotatsu.utils.ext.resolveDp
 import org.koitharu.kotatsu.utils.progress.Progress
 
 class FeedFragment : BaseFragment<FragmentFeedBinding>(), PaginationScrollListener.Callback,
@@ -98,6 +99,7 @@ class FeedFragment : BaseFragment<FragmentFeedBinding>(), PaginationScrollListen
 
 	override fun onWindowInsetsChanged(insets: Insets) {
 		binding.recyclerView.updatePadding(
+			top = resources.resolveDp(64) + insets.top,
 			left = insets.left,
 			right = insets.right,
 			bottom = insets.bottom

--- a/app/src/main/java/org/koitharu/kotatsu/tracker/ui/FeedFragment.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/tracker/ui/FeedFragment.kt
@@ -5,6 +5,7 @@ import android.view.*
 import androidx.appcompat.app.AlertDialog
 import androidx.core.graphics.Insets
 import androidx.core.view.updatePadding
+import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.snackbar.Snackbar
 import org.koin.android.ext.android.get
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -12,7 +13,6 @@ import org.koitharu.kotatsu.R
 import org.koitharu.kotatsu.base.ui.BaseFragment
 import org.koitharu.kotatsu.base.ui.list.OnListItemClickListener
 import org.koitharu.kotatsu.base.ui.list.PaginationScrollListener
-import org.koitharu.kotatsu.base.ui.list.decor.SpacingItemDecoration
 import org.koitharu.kotatsu.core.model.Manga
 import org.koitharu.kotatsu.databinding.FragmentFeedBinding
 import org.koitharu.kotatsu.details.ui.DetailsActivity
@@ -20,7 +20,7 @@ import org.koitharu.kotatsu.list.ui.model.ListModel
 import org.koitharu.kotatsu.tracker.ui.adapter.FeedAdapter
 import org.koitharu.kotatsu.tracker.work.TrackWorker
 import org.koitharu.kotatsu.utils.ext.getDisplayMessage
-import org.koitharu.kotatsu.utils.ext.resolveDp
+import org.koitharu.kotatsu.utils.ext.measureHeight
 import org.koitharu.kotatsu.utils.progress.Progress
 
 class FeedFragment : BaseFragment<FragmentFeedBinding>(), PaginationScrollListener.Callback,
@@ -99,7 +99,7 @@ class FeedFragment : BaseFragment<FragmentFeedBinding>(), PaginationScrollListen
 
 	override fun onWindowInsetsChanged(insets: Insets) {
 		binding.recyclerView.updatePadding(
-			top = resources.resolveDp(64) + insets.top,
+			top = requireActivity().findViewById<AppBarLayout>(R.id.appbar).measureHeight(),
 			left = insets.left,
 			right = insets.right,
 			bottom = insets.bottom

--- a/app/src/main/res/layout-w600dp-land/fragment_details.xml
+++ b/app/src/main/res/layout-w600dp-land/fragment_details.xml
@@ -265,7 +265,6 @@
 
 		<com.google.android.material.progressindicator.LinearProgressIndicator
 			android:id="@+id/progressBar"
-			style="@style/Widget.AppCompat.ProgressBar.Horizontal"
 			android:layout_width="0dp"
 			android:layout_height="wrap_content"
 			android:indeterminate="true"

--- a/app/src/main/res/layout-w600dp-port/fragment_details.xml
+++ b/app/src/main/res/layout-w600dp-port/fragment_details.xml
@@ -272,7 +272,6 @@
 
 		<com.google.android.material.progressindicator.LinearProgressIndicator
 			android:id="@+id/progressBar"
-			style="@style/Widget.AppCompat.ProgressBar.Horizontal"
 			android:layout_width="0dp"
 			android:layout_height="wrap_content"
 			android:indeterminate="true"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -12,11 +12,18 @@
 		android:layout_width="match_parent"
 		android:layout_height="match_parent">
 
+		<androidx.fragment.app.FragmentContainerView
+			android:id="@id/container"
+			android:layout_width="match_parent"
+			android:layout_height="match_parent"
+			app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />
+
 		<com.google.android.material.appbar.AppBarLayout
 			android:id="@+id/appbar"
 			style="@style/Widget.Kotatsu.AppBar"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
+			android:background="@android:color/transparent"
 			android:stateListAnimator="@null"
 			app:elevation="0dp">
 
@@ -45,6 +52,7 @@
 
 					<org.koitharu.kotatsu.search.ui.widget.SearchEditText
 						android:id="@+id/searchView"
+						style="@style/Widget.Kotatsu.SearchView"
 						android:layout_width="match_parent"
 						android:layout_height="match_parent"
 						android:background="@null"
@@ -52,6 +60,7 @@
 						android:hint="@string/search_manga"
 						android:imeOptions="actionSearch"
 						android:importantForAutofill="no"
+						android:paddingBottom="1dp"
 						android:singleLine="true" />
 
 				</com.google.android.material.appbar.MaterialToolbar>
@@ -59,12 +68,6 @@
 			</com.google.android.material.card.MaterialCardView>
 
 		</com.google.android.material.appbar.AppBarLayout>
-
-		<androidx.fragment.app.FragmentContainerView
-			android:id="@id/container"
-			android:layout_width="match_parent"
-			android:layout_height="match_parent"
-			app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />
 
 		<com.google.android.material.floatingactionbutton.FloatingActionButton
 			android:id="@+id/fab"

--- a/app/src/main/res/layout/fragment_favourites.xml
+++ b/app/src/main/res/layout/fragment_favourites.xml
@@ -4,8 +4,7 @@
 	xmlns:app="http://schemas.android.com/apk/res-auto"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
-	android:orientation="vertical"
-	android:paddingTop="64dp">
+	android:orientation="vertical">
 
 	<com.google.android.material.tabs.TabLayout
 		android:id="@+id/tabs"

--- a/app/src/main/res/layout/fragment_favourites.xml
+++ b/app/src/main/res/layout/fragment_favourites.xml
@@ -4,7 +4,8 @@
 	xmlns:app="http://schemas.android.com/apk/res-auto"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
-	android:orientation="vertical">
+	android:orientation="vertical"
+	android:paddingTop="64dp">
 
 	<com.google.android.material.tabs.TabLayout
 		android:id="@+id/tabs"

--- a/app/src/main/res/layout/sheet_pages.xml
+++ b/app/src/main/res/layout/sheet_pages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
+<LinearLayout
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:app="http://schemas.android.com/apk/res-auto"
 	xmlns:tools="http://schemas.android.com/tools"
@@ -14,12 +14,11 @@
 		android:layout_height="?attr/actionBarSize"
 		app:liftOnScroll="true">
 
-		<org.koitharu.kotatsu.base.ui.widgets.AnimatedToolbar
+		<com.google.android.material.appbar.MaterialToolbar
 			android:id="@+id/toolbar"
 			style="@style/Widget.Kotatsu.Toolbar"
 			android:layout_width="match_parent"
 			android:layout_height="match_parent"
-			android:animateLayoutChanges="true"
 			app:navigationIcon="@drawable/ic_cross" />
 
 	</com.google.android.material.appbar.AppBarLayout>
@@ -28,7 +27,6 @@
 		android:id="@+id/recyclerView"
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
-		android:layout_marginTop="?actionBarSize"
 		android:clipToPadding="false"
 		android:padding="@dimen/grid_spacing"
 		android:scrollbars="vertical"
@@ -36,4 +34,4 @@
 		app:spanCount="3"
 		tools:listitem="@layout/item_page_thumb" />
 
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</LinearLayout>

--- a/app/src/main/res/values-v23/themes.xml
+++ b/app/src/main/res/values-v23/themes.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-
-	<style name="AppTheme" parent="Base.AppTheme">
-		<item name="android:statusBarColor">@android:color/transparent</item>
-	</style>
-
-</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,7 +6,7 @@
 
 	<style name="Widget.Kotatsu.AppBar" parent="@style/Widget.Design.AppBarLayout">
 		<item name="android:background">?attr/colorSurface</item>
-		<item name="android:elevation">8dp</item>
+		<item name="android:elevation">4dp</item>
 	</style>
 
 	<style name="Widget.Kotatsu.Sheet.AppBar" parent="@style/Widget.Kotatsu.AppBar">
@@ -39,6 +39,8 @@
 		<item name="iconifiedByDefault">false</item>
 		<item name="searchIcon">@null</item>
 		<item name="queryBackground">@null</item>
+		<item name="android:textColorHint">?attr/colorControlNormal</item>
+		<item name="android:textSize">18sp</item>
 	</style>
 
 	<style name="Widget.Kotatsu.Chip" parent="Widget.MaterialComponents.Chip.Action">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -13,7 +13,7 @@
 
 		<!-- Window decor -->
 		<item name="android:windowLightStatusBar" tools:targetApi="m">@bool/use_light_status</item>
-		<item name="android:statusBarColor">@android:color/transparent</item>
+		<item name="android:statusBarColor">@color/nav_bar_scrim</item>
 		<item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">@bool/use_light_navigation</item>
 		<item name="android:navigationBarColor">@color/nav_bar_scrim</item>
 		<item name="popupTheme">@style/ThemeOverlay.Kotatsu</item>


### PR DESCRIPTION
1. Now the AppBarLayout is transparent and the content is visible under it
![image](https://user-images.githubusercontent.com/61558546/130773124-8c8025a3-5f55-410e-8410-0e6da8977e94.png)
2. Fixed crashes on tablets (removed `style="@style/Widget.AppCompat.ProgressBar.Horizontal"` of `LinearProgressIndicator` in `fragment_details`)
3. I had to abandon the `AnimatedToolbar` in `sheet_pages`, the Toolbar with text was not full-length on the tablet, it was cropped, which is strange
4. Other minor edits
-----------------------
However, there was one question. Do we need to do something with the filter, i.e. move it from DrawerLayout to BottomSheet?
![image](https://user-images.githubusercontent.com/61558546/130773982-e4d79050-1c42-419c-8b05-d8e6c01090e8.png)