### PR TITLE
Add new source MangaOwl, fix GroupLe sites

### DIFF
--- a/app/src/main/java/org/koitharu/kotatsu/core/model/MangaSource.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/core/model/MangaSource.kt
@@ -39,7 +39,8 @@ enum class MangaSource(
 	NINEMANGA_IT("NineManga Italiano", "it", NineMangaRepository.Italiano::class.java),
 	NINEMANGA_BR("NineManga Brasil", "pt", NineMangaRepository.Brazil::class.java),
 	NINEMANGA_FR("NineManga Français", "fr", NineMangaRepository.Francais::class.java),
-	EXHENTAI("ExHentai", null, ExHentaiRepository::class.java)
+	EXHENTAI("ExHentai", null, ExHentaiRepository::class.java),
+	MANGAOWL("MangaOwl", "en", MangaOwlRepository::class.java)
 	;
 
 	@get:Throws(NoBeanDefFoundException::class)

--- a/app/src/main/java/org/koitharu/kotatsu/core/parser/ParserModule.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/core/parser/ParserModule.kt
@@ -33,4 +33,5 @@ val parserModule
 		factory<MangaRepository>(named(MangaSource.NINEMANGA_IT)) { NineMangaRepository.Italiano(get()) }
 		factory<MangaRepository>(named(MangaSource.NINEMANGA_FR)) { NineMangaRepository.Francais(get()) }
 		factory<MangaRepository>(named(MangaSource.EXHENTAI)) { ExHentaiRepository(get()) }
+		factory<MangaRepository>(named(MangaSource.MANGAOWL)) { MangaOwlRepository(get()) }
 	}

--- a/app/src/main/java/org/koitharu/kotatsu/core/parser/site/MangaOwlRepository.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/core/parser/site/MangaOwlRepository.kt
@@ -1,0 +1,159 @@
+package org.koitharu.kotatsu.core.parser.site
+
+import org.koitharu.kotatsu.base.domain.MangaLoaderContext
+import org.koitharu.kotatsu.core.exceptions.ParseException
+import org.koitharu.kotatsu.core.model.*
+import org.koitharu.kotatsu.core.parser.RemoteMangaRepository
+import org.koitharu.kotatsu.utils.ext.*
+import java.util.*
+
+class MangaOwlRepository(loaderContext: MangaLoaderContext) : RemoteMangaRepository(loaderContext) {
+
+	override val source = MangaSource.MANGAOWL
+
+	override val defaultDomain = "mangaowls.com"
+
+	override val sortOrders: Set<SortOrder> = EnumSet.of(
+		SortOrder.POPULARITY,
+		SortOrder.NEWEST,
+		SortOrder.UPDATED
+	)
+
+	override suspend fun getList2(
+		offset: Int,
+		query: String?,
+		tags: Set<MangaTag>?,
+		sortOrder: SortOrder?,
+	): List<Manga> {
+		val page = (offset / 36f).toIntUp().inc()
+		val link = buildString {
+			append("https://")
+			append(getDomain())
+			when {
+				!query.isNullOrEmpty() -> {
+					append("/search/${page}?search=")
+					append(query.urlEncoded())
+				}
+				!tags.isNullOrEmpty() -> {
+					for (tag in tags) {
+						append(tag.key)
+					}
+					append("/${page}?type=${getAlternativeSortKey(sortOrder)}")
+				}
+				else -> {
+					append("/${getSortKey(sortOrder)}/${page}")
+				}
+			}
+		}
+		val doc = loaderContext.httpGet(link).parseHtml()
+		val slides = doc.body().select("ul.slides") ?: parseFailed("An error occurred while parsing")
+		val items = slides.select("div.col-md-2")
+		return items.mapNotNull { item ->
+			val href = item.select("h6 a").attr("href") ?: return@mapNotNull null
+			Manga(
+				id = generateUid(href),
+				title = item.select("h6 a").text(),
+				coverUrl = item.select("div.img-responsive").attr("abs:data-background-image"),
+				altTitle = item.select("h6 a").attr("alt") ?: return@mapNotNull null,
+				author = null,
+				rating = runCatching {
+					item.selectFirst("div.block-stars")
+						?.text()
+						?.toFloatOrNull()
+						?.div(10f)
+				}.getOrNull() ?: Manga.NO_RATING,
+				url = href,
+				publicUrl = href.withDomain(),
+				source = source
+			)
+		}
+	}
+
+	override suspend fun getDetails(manga: Manga): Manga {
+		val doc = loaderContext.httpGet(manga.publicUrl).parseHtml()
+		val info = doc.body().selectFirst("div.single_detail") ?: parseFailed("An error occurred while parsing")
+		val table = doc.body().selectFirst("div.single-grid-right") ?: parseFailed("An error occurred while parsing")
+		return manga.copy(
+			description = info.selectFirst(".description")?.html(),
+			largeCoverUrl = info.select("img").first()?.let { img ->
+				if (img.hasAttr("data-src")) img.attr("abs:data-src") else img.attr("abs:src")
+			},
+			author = info.select("p.fexi_header_para a.author_link").text(),
+			state = parseStatus(info.select("p.fexi_header_para:contains(status)").first()?.ownText()),
+			tags = manga.tags + info.select("div.col-xs-12.col-md-8.single-right-grid-right > p > a[href*=genres]")
+				.mapNotNull {
+					val a = it.selectFirst("a") ?: return@mapNotNull null
+					MangaTag(
+						title = a.text(),
+						key = a.attr("href"),
+						source = source
+					)
+				},
+			chapters = table.select("div.table.table-chapter-list").select("li.list-group-item.chapter_list").asReversed().mapIndexed { i, li ->
+				val a = li.select("a")
+				val href = a.attr("href").ifEmpty {
+					parseFailed("Link is missing")
+				}
+				MangaChapter(
+					id = generateUid(href),
+					name = a.select("label").text(),
+					number = i + 1,
+					url = href,
+					source = MangaSource.MANGAOWL
+				)
+			}
+		)
+	}
+
+	override suspend fun getPages(chapter: MangaChapter): List<MangaPage> {
+		val fullUrl = chapter.url.withDomain()
+		val doc = loaderContext.httpGet(fullUrl).parseHtml()
+		val root = doc.body().select("div.item img.owl-lazy") ?: throw ParseException("Root not found")
+		return root.map { div ->
+			val url = div?.attr("abs:data-src") ?: parseFailed("Page image not found")
+			MangaPage(
+				id = generateUid(url),
+				url = url,
+				referer = fullUrl,
+				source = MangaSource.MANGAOWL
+			)
+		}
+	}
+
+	private fun parseStatus(status: String?) = when {
+		status == null -> null
+		status.contains("Ongoing") -> MangaState.ONGOING
+		status.contains("Completed") -> MangaState.FINISHED
+		else -> null
+	}
+
+	override suspend fun getTags(): Set<MangaTag> {
+		val doc = loaderContext.httpGet("https://${getDomain()}/").parseHtml()
+		val root = doc.body().select("ul.dropdown-menu.multi-column.columns-3").select("li")
+		return root.mapToSet { p ->
+			val a = p.selectFirst("a") ?: parseFailed("a is null")
+			MangaTag(
+				title = a.text().toCamelCase(),
+				key = a.attr("href"),
+				source = source
+			)
+		}
+	}
+
+	private fun getSortKey(sortOrder: SortOrder?) =
+		when (sortOrder ?: sortOrders.minByOrNull { it.ordinal }) {
+			SortOrder.POPULARITY -> "popular"
+			SortOrder.NEWEST -> "new_release"
+			SortOrder.UPDATED -> "lastest"
+			else -> "lastest"
+		}
+
+	private fun getAlternativeSortKey(sortOrder: SortOrder?) =
+		when (sortOrder ?: sortOrders.minByOrNull { it.ordinal }) {
+			SortOrder.POPULARITY -> "0"
+			SortOrder.NEWEST -> "2"
+			SortOrder.UPDATED -> "3"
+			else -> "3"
+		}
+
+}

--- a/app/src/main/java/org/koitharu/kotatsu/core/parser/site/ReadmangaRepository.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/core/parser/site/ReadmangaRepository.kt
@@ -5,6 +5,6 @@ import org.koitharu.kotatsu.core.model.MangaSource
 
 class ReadmangaRepository(loaderContext: MangaLoaderContext) : GroupleRepository(loaderContext) {
 
-	override val defaultDomain = "readmanga.live"
+	override val defaultDomain = "readmanga.io"
 	override val source = MangaSource.READMANGA_RU
 }

--- a/app/src/main/java/org/koitharu/kotatsu/details/ui/DetailsActivity.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/details/ui/DetailsActivity.kt
@@ -85,13 +85,16 @@ class DetailsActivity : BaseActivity<ActivityDetailsBinding>(),
 				finishAfterTransition()
 			}
 			else -> {
-				Snackbar.make(binding.pager, e.getDisplayMessage(resources), Snackbar.LENGTH_LONG)
+				Snackbar.make(binding.coordinator, e.getDisplayMessage(resources), Snackbar.LENGTH_LONG)
 					.show()
 			}
 		}
 	}
 
 	override fun onWindowInsetsChanged(insets: Insets) {
+		binding.coordinator.updatePadding(
+			bottom = insets.bottom
+		)
 		binding.toolbar.updatePadding(
 			top = insets.top,
 			left = insets.left,

--- a/app/src/main/java/org/koitharu/kotatsu/details/ui/DetailsFragment.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/details/ui/DetailsFragment.kt
@@ -5,6 +5,7 @@ import android.text.Spanned
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.Insets
 import androidx.core.net.toUri
 import androidx.core.text.parseAsHtml
@@ -23,13 +24,13 @@ import org.koitharu.kotatsu.base.ui.widgets.ChipsView
 import org.koitharu.kotatsu.core.model.Manga
 import org.koitharu.kotatsu.core.model.MangaHistory
 import org.koitharu.kotatsu.core.model.MangaSource
+import org.koitharu.kotatsu.core.model.MangaState
 import org.koitharu.kotatsu.databinding.FragmentDetailsBinding
 import org.koitharu.kotatsu.favourites.ui.categories.select.FavouriteCategoriesDialog
 import org.koitharu.kotatsu.reader.ui.ReaderActivity
 import org.koitharu.kotatsu.reader.ui.ReaderState
 import org.koitharu.kotatsu.utils.FileSizeUtils
 import org.koitharu.kotatsu.utils.ext.*
-import kotlin.random.Random
 
 class DetailsFragment : BaseFragment<FragmentDetailsBinding>(), View.OnClickListener,
 	View.OnLongClickListener {
@@ -52,6 +53,8 @@ class DetailsFragment : BaseFragment<FragmentDetailsBinding>(), View.OnClickList
 
 	private fun onMangaUpdated(manga: Manga) {
 		with(binding) {
+
+			// Main
 			imageViewCover.newImageRequest(manga.largeCoverUrl ?: manga.coverUrl)
 				.referer(manga.publicUrl)
 				.fallback(R.drawable.ic_placeholder)
@@ -66,6 +69,28 @@ class DetailsFragment : BaseFragment<FragmentDetailsBinding>(), View.OnClickList
 			textViewDescription.text =
 				manga.description?.parseAsHtml()?.takeUnless(Spanned::isBlank)
 					?: getString(R.string.no_description)
+			when (manga.state) {
+				MangaState.FINISHED -> {
+					textViewState.apply {
+						text = resources.getString(R.string.state_finished)
+						drawableStart = ResourcesCompat.getDrawable(resources, R.drawable.ic_state_finished, context.theme)
+					}
+				}
+				MangaState.ONGOING -> {
+					textViewState.apply {
+						text = resources.getString(R.string.state_ongoing)
+						drawableStart = ResourcesCompat.getDrawable(resources, R.drawable.ic_state_ongoing, context.theme)
+					}
+				}
+				else -> {
+					textViewState.apply {
+						text = resources.getString(R.string.state_unknown)
+						drawableStart = ResourcesCompat.getDrawable(resources, R.drawable.ic_state_unknown, context.theme)
+					}
+				}
+			}
+
+			// Info containers
 			if (manga.chapters?.isNotEmpty() == true) {
 				chaptersContainer.isVisible = true
 				textViewChapters.text = manga.chapters.let {
@@ -96,10 +121,14 @@ class DetailsFragment : BaseFragment<FragmentDetailsBinding>(), View.OnClickList
 			} else {
 				sizeContainer.isVisible = false
 			}
+
+			// Buttons
 			buttonFavorite.setOnClickListener(this@DetailsFragment)
 			buttonRead.setOnClickListener(this@DetailsFragment)
 			buttonRead.setOnLongClickListener(this@DetailsFragment)
 			buttonRead.isEnabled = !manga.chapters.isNullOrEmpty()
+
+			// Chips
 			bindTags(manga)
 		}
 	}

--- a/app/src/main/java/org/koitharu/kotatsu/search/ui/SearchActivity.kt
+++ b/app/src/main/java/org/koitharu/kotatsu/search/ui/SearchActivity.kt
@@ -51,6 +51,9 @@ class SearchActivity : BaseActivity<ActivitySearchBinding>(), SearchView.OnQuery
 			left = insets.left,
 			right = insets.right
 		)
+		binding.container.updatePadding(
+			bottom = insets.bottom
+		)
 	}
 
 	override fun onQueryTextSubmit(query: String?): Boolean {

--- a/app/src/main/res/drawable/ic_state_finished.xml
+++ b/app/src/main/res/drawable/ic_state_finished.xml
@@ -1,0 +1,5 @@
+<vector android:height="16dp" android:tint="?attr/colorControlNormal"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="16dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_state_ongoing.xml
+++ b/app/src/main/res/drawable/ic_state_ongoing.xml
@@ -1,0 +1,6 @@
+<vector android:height="16dp" android:tint="?attr/colorControlNormal"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="16dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M12.5,7H11v6l5.25,3.15 0.75,-1.23 -4.5,-2.67z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_state_unknown.xml
+++ b/app/src/main/res/drawable/ic_state_unknown.xml
@@ -1,0 +1,5 @@
+<vector android:height="16dp" android:tint="?attr/colorControlNormal"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="16dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M10,19H13V22H10V19M12,2C17.35,2.22 19.68,7.62 16.5,11.67C15.67,12.67 14.33,13.33 13.67,14.17C13,15 13,16 13,17H10C10,15.33 10,13.92 10.67,12.92C11.33,11.92 12.67,11.33 13.5,10.67C15.92,8.43 15.32,5.26 12,5A3,3 0 0,0 9,8H6A6,6 0 0,1 12,2Z"/>
+</vector>

--- a/app/src/main/res/layout-w600dp-land/fragment_details.xml
+++ b/app/src/main/res/layout-w600dp-land/fragment_details.xml
@@ -6,6 +6,7 @@
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
 	android:scrollbars="vertical"
+	android:clipToPadding="false"
 	app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
 	<androidx.constraintlayout.widget.ConstraintLayout
@@ -87,6 +88,20 @@
 					app:layout_constraintStart_toStartOf="@id/textView_title"
 					app:layout_constraintTop_toBottomOf="@id/textView_subtitle"
 					tools:text="@tools:sample/full_names" />
+
+				<TextView
+					android:id="@+id/textView_state"
+					android:layout_width="0dp"
+					android:layout_height="wrap_content"
+					android:layout_marginTop="4dp"
+					android:drawablePadding="4dp"
+					android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle2"
+					android:textColor="?android:attr/textColorSecondary"
+					app:layout_constraintEnd_toEndOf="@id/textView_title"
+					app:layout_constraintStart_toStartOf="@id/textView_title"
+					app:layout_constraintTop_toBottomOf="@id/textView_author"
+					tools:drawableStart="@drawable/ic_state_finished"
+					tools:text="Finished" />
 
 				<LinearLayout
 					android:id="@+id/info_layout"
@@ -269,12 +284,12 @@
 			android:layout_height="wrap_content"
 			android:indeterminate="true"
 			android:visibility="gone"
-			app:showAnimationBehavior="inward"
 			app:hideAnimationBehavior="outward"
 			app:layout_constraintBottom_toTopOf="parent"
 			app:layout_constraintEnd_toEndOf="parent"
 			app:layout_constraintStart_toStartOf="parent"
 			app:layout_constraintTop_toTopOf="parent"
+			app:showAnimationBehavior="inward"
 			tools:visibility="visible" />
 
 	</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout-w600dp-port/fragment_details.xml
+++ b/app/src/main/res/layout-w600dp-port/fragment_details.xml
@@ -6,6 +6,7 @@
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
 	android:scrollbars="vertical"
+	android:clipToPadding="false"
 	app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
 	<androidx.constraintlayout.widget.ConstraintLayout
@@ -88,6 +89,20 @@
 					app:layout_constraintStart_toStartOf="@id/textView_title"
 					app:layout_constraintTop_toBottomOf="@id/textView_subtitle"
 					tools:text="@tools:sample/full_names" />
+
+				<TextView
+					android:id="@+id/textView_state"
+					android:layout_width="0dp"
+					android:layout_height="wrap_content"
+					android:layout_marginTop="4dp"
+					android:drawablePadding="4dp"
+					android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle2"
+					android:textColor="?android:attr/textColorSecondary"
+					app:layout_constraintEnd_toEndOf="@id/textView_title"
+					app:layout_constraintStart_toStartOf="@id/textView_title"
+					app:layout_constraintTop_toBottomOf="@id/textView_author"
+					tools:drawableStart="@drawable/ic_state_finished"
+					tools:text="Finished" />
 
 				<LinearLayout
 					android:id="@+id/info_layout"
@@ -276,12 +291,12 @@
 			android:layout_height="wrap_content"
 			android:indeterminate="true"
 			android:visibility="gone"
-			app:showAnimationBehavior="inward"
 			app:hideAnimationBehavior="outward"
 			app:layout_constraintBottom_toTopOf="parent"
 			app:layout_constraintEnd_toEndOf="parent"
 			app:layout_constraintStart_toStartOf="parent"
 			app:layout_constraintTop_toTopOf="parent"
+			app:showAnimationBehavior="inward"
 			tools:visibility="visible" />
 
 	</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout-w600dp/activity_details.xml
+++ b/app/src/main/res/layout-w600dp/activity_details.xml
@@ -3,8 +3,10 @@
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:app="http://schemas.android.com/apk/res-auto"
 	xmlns:tools="http://schemas.android.com/tools"
+	android:id="@+id/coordinator"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
+	android:clipToPadding="false"
 	tools:context=".details.ui.DetailsActivity">
 
 	<com.google.android.material.appbar.AppBarLayout

--- a/app/src/main/res/layout/activity_details.xml
+++ b/app/src/main/res/layout/activity_details.xml
@@ -3,8 +3,10 @@
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:app="http://schemas.android.com/apk/res-auto"
 	xmlns:tools="http://schemas.android.com/tools"
+	android:id="@+id/coordinator"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
+	android:clipToPadding="false"
 	tools:context=".details.ui.DetailsActivity">
 
 	<com.google.android.material.appbar.AppBarLayout

--- a/app/src/main/res/layout/fragment_chapters.xml
+++ b/app/src/main/res/layout/fragment_chapters.xml
@@ -26,6 +26,7 @@
 		android:layout_alignParentStart="true"
 		android:layout_alignParentEnd="true"
 		android:layout_alignParentBottom="true"
+		android:clipToPadding="false"
 		android:orientation="vertical"
 		android:scrollbarStyle="outsideOverlay"
 		app:fastScrollEnabled="true"

--- a/app/src/main/res/layout/fragment_details.xml
+++ b/app/src/main/res/layout/fragment_details.xml
@@ -6,6 +6,7 @@
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
 	android:scrollbars="vertical"
+	android:clipToPadding="false"
 	app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
 	<androidx.constraintlayout.widget.ConstraintLayout
@@ -87,6 +88,20 @@
 					app:layout_constraintStart_toStartOf="@id/textView_title"
 					app:layout_constraintTop_toBottomOf="@id/textView_subtitle"
 					tools:text="@tools:sample/full_names" />
+
+				<TextView
+					android:id="@+id/textView_state"
+					android:layout_width="0dp"
+					android:layout_height="wrap_content"
+					android:layout_marginTop="4dp"
+					android:drawablePadding="4dp"
+					android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle2"
+					android:textColor="?android:attr/textColorSecondary"
+					app:layout_constraintEnd_toEndOf="@id/textView_title"
+					app:layout_constraintStart_toStartOf="@id/textView_title"
+					app:layout_constraintTop_toBottomOf="@id/textView_author"
+					tools:drawableStart="@drawable/ic_state_finished"
+					tools:text="Finished" />
 
 			</androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -277,12 +292,12 @@
 			android:layout_height="wrap_content"
 			android:indeterminate="true"
 			android:visibility="gone"
-			app:showAnimationBehavior="inward"
 			app:hideAnimationBehavior="outward"
 			app:layout_constraintBottom_toTopOf="parent"
 			app:layout_constraintEnd_toEndOf="parent"
 			app:layout_constraintStart_toStartOf="parent"
 			app:layout_constraintTop_toTopOf="parent"
+			app:showAnimationBehavior="inward"
 			tools:visibility="visible" />
 
 	</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_current_filter.xml
+++ b/app/src/main/res/layout/item_current_filter.xml
@@ -3,7 +3,9 @@
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:app="http://schemas.android.com/apk/res-auto"
 	android:layout_width="match_parent"
-	android:layout_height="wrap_content">
+	android:layout_height="wrap_content"
+	android:paddingStart="8dp"
+	android:paddingEnd="8dp">
 
 	<org.koitharu.kotatsu.base.ui.widgets.ChipsView
 		android:id="@+id/chips_tags"

--- a/app/src/main/res/layout/item_filter_header.xml
+++ b/app/src/main/res/layout/item_filter_header.xml
@@ -9,8 +9,6 @@
 	android:paddingStart="?android:listPreferredItemPaddingStart"
 	android:paddingEnd="?android:listPreferredItemPaddingEnd"
 	android:singleLine="true"
-	android:textAllCaps="true"
-	android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+	android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle2"
 	android:textColor="?android:textColorSecondary"
-	android:textStyle="bold"
 	tools:text="@tools:sample/lorem[2]" />

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -237,4 +237,7 @@
 	<string name="auth_not_supported_by">Авторизация в %s не поддерживается</string>
 	<string name="text_clear_cookies_prompt">Вы выйдете из всех источников, в которых Вы авторизованы</string>
     <string name="genres">Жанры</string>
+	<string name="state_finished">Завершено</string>
+    <string name="state_ongoing">Онгоинг</string>
+    <string name="state_unknown">Неизвестно</string>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -20,7 +20,7 @@
 	<dimen name="manga_list_details_item_height">120dp</dimen>
 	<dimen name="chapter_list_item_height">46dp</dimen>
 	<dimen name="preferred_grid_width">120dp</dimen>
-	<dimen name="header_height">34dp</dimen>
+	<dimen name="header_height">48dp</dimen>
 	<dimen name="elevation_large">16dp</dimen>
 	<dimen name="list_footer_height_inner">36dp</dimen>
 	<dimen name="list_footer_height_outer">48dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -240,4 +240,7 @@
 	<string name="auth_not_supported_by">Authorization on %s is not supported</string>
 	<string name="text_clear_cookies_prompt">You will be logged out from all sources that you are authorized in</string>
     <string name="genres">Genres</string>
+	<string name="state_finished">Finished</string>
+    <string name="state_ongoing">Ongoing</string>
+    <string name="state_unknown">Unknown</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -48,6 +48,7 @@
 		<item name="chipStrokeColor">?attr/colorPrimary</item>
 		<item name="chipBackgroundColor">@android:color/transparent</item>
 		<item name="chipIconTint">?attr/colorPrimary</item>
+		<item name="closeIconTint">?attr/colorPrimary</item>
 
 		<!-- Smaller text/height -->
 		<item name="android:textSize">12sp</item>


### PR DESCRIPTION
1. Был добавлен парсер сайта MangaOwl (по просьбе с 4PDA)
2. Сменил домен readmanga с live на io. Поставил User-Agent на сайты GroupLe. Вроде всё должно заработать. Цитата с сайта ReadManga:
> (Рид и Минт были закрыты для посетителей из некоторых стран. Для постоянных читателей можно выставить специальный User Agent для сайтов readmangafun, и блокировка будет снята.)
3. Как я понял, с 30 сентября пользователи с устройствами ниже Android 7.1.1 не смогут просматривать обложки сайтов GroupLe, так как корневые сертификаты уже устарели (https://readmanga.io/news/show_slomali_internet). С другими сайтами проблем не видел, но могут появиться внезапно и не понятно когда их ждать.
4. Ну и по мелочи, добавил надпись, говорящую о статусе манги на экран информации о манге, поигрался с padding'ами (Snackbar был за навбаром на экране информации о манге).